### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/Fileupload/security/code-scanning/3](https://github.com/majorsilence/Fileupload/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block limiting the `GITHUB_TOKEN` to the least privileges required. Since all three jobs only need to read the repository contents, a minimal `contents: read` permission is sufficient. Adding this at the workflow root will apply it to all jobs that don’t override it.

Concretely, in `.github/workflows/dotnet.yml`, add a top‑level `permissions:` section after the `name:` (or before `jobs:`), with `contents: read`. This change does not alter any build or artifact behavior and requires no additional imports or steps. No job‑specific overrides are needed because none of the jobs need write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
